### PR TITLE
Make the fraction directive parameter optional

### DIFF
--- a/src/ng-currency.js
+++ b/src/ng-currency.js
@@ -20,7 +20,7 @@ angular.module('ng-currency', [])
                 max: '=max',
                 currencySymbol: '@',
                 ngRequired: '=ngRequired',
-                fraction: '=fraction'
+                fraction: '=?fraction'
             },
             link: function (scope, element, attrs, ngModel) {
 


### PR DESCRIPTION
Resolves fraction error for 0.8.x branch.

> Expression 'undefined' in attribute 'fraction' used with directive 'ngCurrency' is non-assignable!
